### PR TITLE
Avoid TypeError in Room.js, allowing room to load

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1687,7 +1687,7 @@ function hide(elem) {
 }
 
 function show(elem) {
-    if (elem.classList.contains('hidden')) elem.classList.toggle('hidden');
+    if (elem && elem.classList && elem.classList.contains('hidden')) elem.classList.toggle('hidden');
 }
 
 function disable(elem, disabled) {


### PR DESCRIPTION
Fixing:
RoomClient.js:523 Join error: TypeError: Cannot read properties of undefined (reading 'contains')
    at show (Room.js:1690:24)
    at handleRules (Rules.js:222:9)
    at RoomClient.handleRoomInfo (RoomClient.js:597:13)
    at RoomClient.joinAllowed (RoomClient.js:546:20)
    at RoomClient.js:520:28